### PR TITLE
Improve build documentation and add Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Ignore compiled binaries
+grasp
+ils
+tabu
+simulated_annealing
+leitura_exec
+
+# Ignore results and datasets
+resultados/
+instances.zip
+
+# Ignore editor config
+.vscode/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+CXX = g++
+CXXFLAGS = -std=c++17 -O2 -Wall
+
+BINARIES = grasp ils tabu simulated_annealing leitura_exec
+
+all: $(BINARIES)
+
+%: %.cpp
+	$(CXX) $(CXXFLAGS) $< -o $@
+
+clean:
+	rm -f $(BINARIES)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# Otimizacao-Grafos
+# Otimização de Grafos
+
+Este repositório contém implementações em C++ de diferentes heurísticas para o problema de mochila com penalidades. Os programas disponíveis são:
+
+- **grasp** – Algoritmo GRASP
+- **ils** – Iterated Local Search
+- **tabu** – Busca Tabu
+- **simulated_annealing** – Simulated Annealing
+- **leitura_exec** – Script auxiliar para executar todos os algoritmos nas instâncias
+
+## Compilação
+
+Para compilar todas as heurísticas utilize o comando abaixo (é necessário o `g++`):
+
+```bash
+make
+```
+
+## Execução
+
+Cada algoritmo recebe dois argumentos: caminho para o arquivo de entrada e caminho do arquivo de saída. Exemplo:
+
+```bash
+./grasp instances/scenario1/correlated_sc1/300/kpfs_1.txt saida.txt
+```
+
+O programa `leitura_exec` automatiza a execução em todas as instâncias presentes no diretório `instances` e salva os resultados em `resultados/`.
+


### PR DESCRIPTION
## Summary
- add `.gitignore` to ignore binaries and results
- document build and usage instructions in README
- provide a Makefile for easy compilation
- fix tabs in Makefile rules

## Testing
- `make clean && make`

------
https://chatgpt.com/codex/tasks/task_e_685779924d908329aafaa16a5e9ae065